### PR TITLE
Migrate calculations from VBScript to Python

### DIFF
--- a/commands/merge_adjoining_line_segments.py
+++ b/commands/merge_adjoining_line_segments.py
@@ -2,7 +2,7 @@ import arcpy
 
 def merge_similar_adjoining_segments(bike_ped_auto, strDate):
 
-    bike_ped_auto_merge_adjoined = "C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\BikePedAutoMergeAdjoined_" + strDate
+    bike_ped_auto_merge_adjoined = r"C:\Multimodal Network Data\MultimodalScratchData.gdb\BikePedAutoMergeAdjoined_" + strDate
     dissolve_fields = ["Name", "Oneway", "Speed", "AutoNetwork", "BikeNetwork", "PedNetwork", "SourceData", "ConnectorNetwork", "CartoCode", "AADT", "AADT_YR", "BIKE_L", "BIKE_R", "VERT_LEVEL"]
     arcpy.management.UnsplitLine(bike_ped_auto, bike_ped_auto_merge_adjoined, dissolve_fields)
 

--- a/commands/split_network_segments_at_intersections.py
+++ b/commands/split_network_segments_at_intersections.py
@@ -2,7 +2,7 @@ import arcpy
 
 def split_network_at_intersections(bike_ped_auto, strDate):
 
-    bike_ped_auto_split = "C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\BikePedAutoSplit_" + strDate
+    bike_ped_auto_split = r"C:\Multimodal Network Data\MultimodalScratchData.gdb\BikePedAutoSplit_" + strDate
 
     #: Make feature layer with where clause
     arcpy.MakeFeatureLayer_management(bike_ped_auto, "bike_ped_auto_lyr", "(SourceData = 'Trails' and CartoCode <> '8 - Bridge, Tunnel') OR (SourceData = 'RoadCenterlines' and VERT_LEVEL Not In ('1','2','3'))")

--- a/create_connectors.py
+++ b/create_connectors.py
@@ -1,6 +1,7 @@
 import arcpy
 import datetime
 import time
+import os
 from datetime import date
 from datetime import datetime
 
@@ -15,15 +16,17 @@ strDate = str(today.month).zfill(2) + str(today.day).zfill(2) +  str(today.year)
 
 # global variables
 #bike_ped_auto = r'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MM_NetworkDataset_' + strDate + '.gdb\\NetworkDataset' + '\\BikePedAuto'
-network_dataset = r'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MM_NetworkDataset_' + strDate +  '.gdb\\NetworkDataset'  #### Note ####: change dates for fgdb to current dataset
-bike_ped_auto = r'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MM_NetworkDataset_' + strDate +  '.gdb\\NetworkDataset\\BikePedAuto' #### Note ####: change dates for fgdb to current dataset
+network_dataset = r'C:\Multimodal Network Data\MM_NetworkDataset_' + strDate +  r'.gdb\NetworkDataset'  #### Note ####: change dates for fgdb to current dataset
+bike_ped_auto = r'C:\Multimodal Network Data\MM_NetworkDataset_' + strDate +  r'.gdb\NetworkDataset\BikePedAuto' #### Note ####: change dates for fgdb to current dataset
 ### i'm doing this in the rallup script now...  transit_stops_multipoint = r'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MM_TransitData_02152019.gdb\\TransitStops' #### Note ####: change dates (if it's been updated) for fgdb to current dataset     
-transit_routes = r'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MM_TransitData_02152019.gdb\\TransitRoutes' #### Note ####: change dates (if it's been updated) for fgdb to current dataset
-transit_stops_singlepoints = r"C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\TranStops_" + strDate #### Note ####: change today's dates if rallyup script was not run today
+transit_routes = r'C:\Multimodal Network Data\MM_TransitData_02152019.gdb\TransitRoutes' #### Note ####: change dates (if it's been updated) for fgdb to current dataset
+transit_stops_singlepoints = r"C:\Multimodal Network Data\MultimodalScratchData.gdb\TranStops_" + strDate #### Note ####: change today's dates if rallyup script was not run today
 transit_stops_buffered = ""
 auto_lines_in_buffer = ""
 bike_lines_in_buffer = ""
 ped_lines_in_buffer = ""
+
+MM_scratch_db = r'C:\Multimodal Network Data\MultimodalScratchData.gdb'
 
 # main function
 def main():
@@ -35,7 +38,7 @@ def main():
 
     # create a buffer around the transit stops
     print("buffer the transit stops single points")
-    transit_stops_buffered = r"C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\TranStopBuff_" + strDate
+    transit_stops_buffered = os.path.join(MM_scratch_db, "TranStopBuff_" + strDate)
     arcpy.Buffer_analysis(transit_stops_singlepoints, transit_stops_buffered, 100)
 
     # get network lines that intersect the buffers, for each mode of travel
@@ -45,12 +48,12 @@ def main():
     intersected_auto_network = get_SouceDataUsingSpatialQuery(transit_stops_buffered, bike_ped_auto, "Auto") 
     print("intersect the ped network with the buffers")
     intersected_ped_network = get_SouceDataUsingSpatialQuery(transit_stops_buffered, bike_ped_auto, "Ped") 
-    intersected_bike_network = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\TranStopBike' + '_' + strDate
-    intersected_auto_network = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\TranStopAuto' + '_' + strDate
-    intersected_ped_network = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\TranStopPed' + '_' + strDate
+    intersected_bike_network = os.path.join(MM_scratch_db, 'TranStopBike' + '_' + strDate)
+    intersected_auto_network = os.path.join(MM_scratch_db, 'TranStopAuto' + '_' + strDate)
+    intersected_ped_network = os.path.join(MM_scratch_db, 'TranStopPed' + '_' + strDate)
 
     # convert the network line data (for each of the 3 modes) to vertices 
-    outputVertsToPnts = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\Verts'
+    outputVertsToPnts = os.path.join(MM_scratch_db, 'Verts')
     print("convert the intersected bike verts to points layer")
     intersected_bike_network_verts = arcpy.FeatureVerticesToPoints_management(intersected_bike_network, outputVertsToPnts + 'Bike' + '_' + strDate, "ALL")
     print("convert the intersected auto verts to points layer")
@@ -81,12 +84,12 @@ def main():
 
     # create three seperate feature classs from the transit stop points - so each one can be used separatly in the near analysis and preserve the near data in the fields 
     print("create a separate feature class of transit stops for each near analysis")
-    arcpy.FeatureClassToFeatureClass_conversion(transit_stops_singlepoints, 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb', 'StopNearBike_' + strDate)
-    arcpy.FeatureClassToFeatureClass_conversion(transit_stops_singlepoints, 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb', 'StopNearAuto_' + strDate)
-    arcpy.FeatureClassToFeatureClass_conversion(transit_stops_singlepoints, 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb', 'StopNearPed_' + strDate)
-    stops_near_bike = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\StopNearBike_' + strDate
-    stops_near_auto = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\StopNearAuto_' + strDate
-    stops_near_ped = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\StopNearPed_' + strDate
+    arcpy.FeatureClassToFeatureClass_conversion(transit_stops_singlepoints, MM_scratch_db, 'StopNearBike_' + strDate)
+    arcpy.FeatureClassToFeatureClass_conversion(transit_stops_singlepoints, MM_scratch_db, 'StopNearAuto_' + strDate)
+    arcpy.FeatureClassToFeatureClass_conversion(transit_stops_singlepoints, MM_scratch_db, 'StopNearPed_' + strDate)
+    stops_near_bike = os.path.join(MM_scratch_db, 'StopNearBike_' + strDate)
+    stops_near_auto = os.path.join(MM_scratch_db, 'StopNearAuto_' + strDate)
+    stops_near_ped = os.path.join(MM_scratch_db, 'StopNearPed_' + strDate)
 
     # run near analysis on the transit stops to see the nearest bike/auto/ped vertex
     print("run near analysis on bike")
@@ -108,26 +111,26 @@ def main():
 
     ## remove the -1 from the NEAR_FID field, before creating the connector lines - by way of making a new feture class
     print("remove -1 values from bike")
-    arcpy.FeatureClassToFeatureClass_conversion(intersected_bike_network_verts, 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb', 'ConnPntsBike_' + strDate, "NEAR_FID <> -1")
+    arcpy.FeatureClassToFeatureClass_conversion(intersected_bike_network_verts, MM_scratch_db, 'ConnPntsBike_' + strDate, "NEAR_FID <> -1")
     print("remove -1 values from auto")
-    arcpy.FeatureClassToFeatureClass_conversion(intersected_auto_network_verts, 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb', 'ConnPntsAuto_' + strDate, "NEAR_FID <> -1")
+    arcpy.FeatureClassToFeatureClass_conversion(intersected_auto_network_verts, MM_scratch_db, 'ConnPntsAuto_' + strDate, "NEAR_FID <> -1")
     print("remove -1 values from auto")
-    arcpy.FeatureClassToFeatureClass_conversion(intersected_ped_network_verts, 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb', 'ConnPntsPed_' + strDate, "NEAR_FID <> -1")
-    conn_pnts_bike = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\ConnPntsBike_' + strDate
-    conn_pnts_auto = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\ConnPntsAuto_' + strDate
-    conn_pnts_ped = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\ConnPntsPed_' + strDate
+    arcpy.FeatureClassToFeatureClass_conversion(intersected_ped_network_verts, MM_scratch_db, 'ConnPntsPed_' + strDate, "NEAR_FID <> -1")
+    conn_pnts_bike = os.path.join(MM_scratch_db, 'ConnPntsBike_' + strDate)
+    conn_pnts_auto = os.path.join(MM_scratch_db, 'ConnPntsAuto_' + strDate)
+    conn_pnts_ped = os.path.join(MM_scratch_db, 'ConnPntsPed_' + strDate)
 
     # create lines between the verts
     print("create the connector lines for bike")
-    bike_connectors = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\BikeConn_' + strDate
+    bike_connectors = os.path.join(MM_scratch_db, 'BikeConn_' + strDate)
     arcpy.PointsToLine_management(conn_pnts_bike, bike_connectors, "NEAR_FID","NEAR_FID", "NO_CLOSE")
 
     print("create the connector lines for auto")
-    auto_connectors = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\AutoConn_' + strDate
+    auto_connectors = os.path.join(MM_scratch_db, 'AutoConn_' + strDate)
     arcpy.PointsToLine_management(conn_pnts_auto, auto_connectors, Line_Field="NEAR_FID", Sort_Field="NEAR_FID", Close_Line="NO_CLOSE")
 
     print("create the connector lines for ped")
-    ped_connectors = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\PedConn_' + strDate
+    ped_connectors = os.path.join(MM_scratch_db, 'PedConn_' + strDate)
     arcpy.PointsToLine_management(conn_pnts_ped, ped_connectors, Line_Field="NEAR_FID", Sort_Field="NEAR_FID", Close_Line="NO_CLOSE")
 
     # remove the identical connectors in each feature class
@@ -200,7 +203,7 @@ def get_SouceDataUsingSpatialQuery(spatial_boundary, networkFeatureClass, source
     if matchcount == 0:
         print('no features matched spatial and attribute criteria')
     else:
-        intersected_roads = arcpy.CopyFeatures_management('linesIntersected_lyr', 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\TranStop' + source + '_' + strDate)
+        intersected_roads = arcpy.CopyFeatures_management('linesIntersected_lyr', os.path.join(MM_scratch_db, 'TranStop' + source + '_' + strDate))
         #print('{0} cities that matched criteria written to {0}'.format(matchcount, utrans_IntersectedRoads))
 
     return 'linesIntersected_lyr'

--- a/create_network.py
+++ b/create_network.py
@@ -11,6 +11,9 @@
 #Import system modules
 import arcpy
 import os
+import time
+
+today = time.strftime("%m%d%Y")
 
 try:
     #Check out Network Analyst license if available. Fail if the Network Analyst license is not available.
@@ -21,8 +24,9 @@ try:
     
     #Set local variables
     ##original_network = "C:/data/Region1.gdb/Transportation/Streets_ND"
-    new_network_location = "C:\\Users\\gbunce\\Documents\projects\\MultimodalNetwork\\MM_NetworkDataset_08132024.gdb\\NetworkDataset"
-    xml_template = "C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\network_xml_template\\NDTemplate.xml"
+    # new_network_location = r"C:\\Users\\gbunce\\Documents\projects\\MultimodalNetwork\\MM_NetworkDataset_08132024.gdb\\NetworkDataset"
+    new_network_location = rf"C:\Multimodal Network Data\MM_NetworkDataset_{today}.gdb\NetworkDataset"
+    xml_template = r"C:\Multimodal Network Data\network_xml_template\NDTemplate_update_20250702.xml"
     
     #Create an XML template from the original network dataset
     ##arcpy.na.CreateTemplateFromNetworkDataset(original_network, xml_template)

--- a/create_network.py
+++ b/create_network.py
@@ -26,7 +26,7 @@ try:
     ##original_network = "C:/data/Region1.gdb/Transportation/Streets_ND"
     # new_network_location = r"C:\\Users\\gbunce\\Documents\projects\\MultimodalNetwork\\MM_NetworkDataset_08132024.gdb\\NetworkDataset"
     new_network_location = rf"C:\Multimodal Network Data\MM_NetworkDataset_{today}.gdb\NetworkDataset"
-    xml_template = r"C:\Multimodal Network Data\network_xml_template\NDTemplate_update_20250702.xml"
+    xml_template = r"C:\Multimodal Network Data\network_xml_template\NDTemplate_update_20250702.xml" # Updated template that uses python instead of VBScript
     
     #Create an XML template from the original network dataset
     ##arcpy.na.CreateTemplateFromNetworkDataset(original_network, xml_template)

--- a/create_network_data.py
+++ b/create_network_data.py
@@ -26,7 +26,7 @@ print("The script start time is {}".format(readable_start))
     #: make sure this is pointing to the correct area: \MultimodalScriptData.gdb\BikePedAuto_template_new
 
 #### User Note ####: change dates for fgdb to current dataset (ctrl + f for "#### Note ####:")
-transit_route_source = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MM_TransitData_02152019.gdb\\TransitRoutes' #### Note ####: change transit data date (if it's been updated)
+transit_route_source = r'C:\Multimodal Network Data\MM_TransitData_02152019.gdb\TransitRoutes' #### Note ####: change transit data date (if it's been updated)
 
 # get the date
 today = date.today()
@@ -35,30 +35,30 @@ strDate = str(today.month).zfill(2) + str(today.day).zfill(2) +  str(today.year)
 # global variables
 # utrans_roads = 'Database Connections\DC_TRANSADMIN@UTRANS@utrans.agrc.utah.gov.sde\UTRANS.TRANSADMIN.Centerlines_Edit\UTRANS.TRANSADMIN.Roads_Edit' #: use when not on VPN
 #utrans_trails =  'Database Connections\\DC_TRANSADMIN@UTRANS@utrans.agrc.utah.gov.sde\\UTRANS.TRANSADMIN.Trails_Paths' #: use when not on VPN
-utrans_roads = 'C:\\Users\\gbunce\\Documents\\SGID\\local_sgid_data\\SGID_2024_10_16.gdb\\Roads' #: use when on VPN (update data)
-utrans_trails =  'C:\\Users\\gbunce\\Documents\\SGID\\local_sgid_data\\SGID_2024_10_16.gdb\\TrailsAndPathways' #: use when on VPN (update data)
+utrans_roads = r'C:\Multimodal Network Data\SGID_data_20250702.gdb\Roads' #: use when on VPN (update data)
+utrans_trails =  r'C:\Multimodal Network Data\SGID_data_20250702.gdb\TrailsAndPathways' #: use when on VPN (update data)
 
-network_file_geodatabase = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MM_NetworkDataset_' + strDate + '.gdb'
+network_file_geodatabase = r'C:\Multimodal Network Data\MM_NetworkDataset_' + strDate + '.gdb'
 arcpy.env.workspace = network_file_geodatabase
-fifty_sites_1mile = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScriptData.gdb\\FiftySites_1mile'
-fifty_sites_halfmile = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScriptData.gdb\\FiftySites_halfmile'
-counties_mmp = 'C:\\Users\\gbunce\Documents\\projects\\MultimodalNetwork\\MultimodalScriptData.gdb\\Counties_MMP'
-fgdb_dataset_name = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MM_NetworkDataset_' + strDate + '.gdb\\NetworkDataset'
-bike_ped_auto = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MM_NetworkDataset_' + strDate + '.gdb\\NetworkDataset' + '\\BikePedAuto'
+fifty_sites_1mile = r'C:\Multimodal Network Data\MultimodalScriptData.gdb\FiftySites_1mile'
+fifty_sites_halfmile = r'C:\Multimodal Network Data\MultimodalScriptData.gdb\FiftySites_halfmile'
+counties_mmp = r'C:\Multimodal Network Data\MultimodalScriptData.gdb\Counties_MMP'
+fgdb_dataset_name = r'C:\Multimodal Network Data\MM_NetworkDataset_' + strDate + r'.gdb\NetworkDataset'
+bike_ped_auto = r'C:\Multimodal Network Data\MM_NetworkDataset_' + strDate + r'.gdb\NetworkDataset' + r'\BikePedAuto'
 
 
 # main function
 def main():
     # create new fgdb
     print(network_file_geodatabase)
-    arcpy.CreateFileGDB_management('C:\\Users\\gbunce\Documents\\projects\\MultimodalNetwork', 'MM_NetworkDataset_' + strDate +  '.gdb')
+    arcpy.CreateFileGDB_management(r'C:\Multimodal Network Data', 'MM_NetworkDataset_' + strDate +  '.gdb')
 
     # create dataset in the fgdb
     arcpy.CreateFeatureDataset_management(network_file_geodatabase, 'NetworkDataset', utrans_roads)
 
     # create new feature class in the fgdb
     arcpy.CreateFeatureclass_management(fgdb_dataset_name, "BikePedAuto", "POLYLINE", 
-                                        'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScriptData.gdb\\BikePedAuto_template_new', "DISABLED", "DISABLED", 
+                                        r'C:\Multimodal Network Data\MultimodalScriptData.gdb\BikePedAuto_template_new', "DISABLED", "DISABLED", 
                                         utrans_roads)
 
     # create a list of fields for the BikePedAuto feature class 
@@ -111,7 +111,7 @@ def main():
     #arcpy.FeatureClassToFeatureClass_conversion(bike_ped_auto, fgdb_dataset_name, 'AutoNetwork', "AutoNetwork = 'Y'")
 
     #: Export the BikePedAuto to shapefile
-    arcpy.FeatureClassToFeatureClass_conversion(bike_ped_auto, 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork', 'BikePedAuto_' + strDate + '.shp')
+    arcpy.FeatureClassToFeatureClass_conversion(bike_ped_auto, r'C:\Multimodal Network Data', 'BikePedAuto_' + strDate + '.shp')
 
     print("create_network_data.py script is done!")
 
@@ -119,7 +119,8 @@ def main():
 # this function imports the user-defined utrans roads into the the netork dataset feature class 
 def import_RoadsIntoNetworkDataset(utrans_roads_to_import):
     # get # Get the dictionary of codes and descriptions for cartocode field, for transfering descriptions to RoadClass network field
-    gdb = 'C:\\Users\\gbunce\AppData\\Roaming\\ESRI\ArcGISPro\\Favorites\\internal@SGID@internal.agrc.utah.gov.sde'
+    # gdb = 'C:\\Users\\gbunce\AppData\\Roaming\\ESRI\ArcGISPro\\Favorites\\internal@SGID@internal.agrc.utah.gov.sde'
+    gdb = r'C:\Users\emneemann\AppData\Roaming\Esri\ArcGISPro\Favorites\internal.agrc.utah.gov (2).sde'
     desc_lu = [d.codedValues for d in arcpy.da.ListDomains(gdb) if d.name == 'CVDomain_CartoCode'][0]
     
     # create list of field names
@@ -206,7 +207,7 @@ def import_RoadsIntoNetworkDataset(utrans_roads_to_import):
 
                 # create a list of values that will be used to construct new row
                 insert_row_values = [(utrans_row[0], miles, oneway, source_data, speed_lmt, drive_time, ped_time, bike_time, auto_network, ped_network, bike_network, connector_network, carto_code, aadt, aadt_yr, bike_l, bike_r, vertlevel, utrans_row[12])]
-                print(insert_row_values)
+                # print(insert_row_values)
 
                 # insert the new row with the list of values
                 for insert_row in insert_row_values:
@@ -217,7 +218,7 @@ def import_RoadsIntoNetworkDataset(utrans_roads_to_import):
 def import_TrailsIntoNetworkDataset(utrans_trails_to_import):
     
     # convert features in trail dataset from multipart to singlepart
-    output = 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\trails_singlepart' + '_' + strDate
+    output = r'C:\Multimodal Network Data\MultimodalScratchData.gdb\trails_singlepart' + '_' + strDate
     trails_singlepart = arcpy.MultipartToSinglepart_management(utrans_trails_to_import, output)
     
     # create list of field names
@@ -280,7 +281,7 @@ def import_TrailsIntoNetworkDataset(utrans_trails_to_import):
 
                     # create a list of values that will be used to construct new row
                     insert_row_values = [(utrans_row[0], miles, oneway, source_data, speed_lmt, drive_time, ped_time, bike_time, auto_network, ped_network, bike_network, connector_network, carto_code, utrans_row[5])]
-                    print(insert_row_values)
+                    # print(insert_row_values)
 
                     # insert the new row with the list of values
                     for insert_row in insert_row_values:
@@ -312,7 +313,7 @@ def get_SouceDataUsingSpatialQuery(spatial_boundary, utransFeatureClass, source)
     if matchcount == 0:
         print('no features matched spatial and attribute criteria')
     else:
-        intersected_roads = arcpy.CopyFeatures_management('utransIntersected_lyr', 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\utransIntersected' + source + '_' + strDate)
+        intersected_roads = arcpy.CopyFeatures_management('utransIntersected_lyr', r'C:\Multimodal Network Data\MultimodalScratchData.gdb\utransIntersected' + source + '_' + strDate)
         #print('{0} cities that matched criteria written to {0}'.format(matchcount, utrans_IntersectedRoads))
 
     return 'utransIntersected_lyr'
@@ -335,7 +336,7 @@ def get_SourceDataUsingDefQuery(where_clause, utransFeatureClass, source):
     if matchcount == 0:
         print('no features matched spatial and attribute criteria')
     else:
-        intersected_roads = arcpy.CopyFeatures_management('utransQueried_lyr', 'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\utransWhereClause' + source + '_' + strDate)
+        intersected_roads = arcpy.CopyFeatures_management('utransQueried_lyr', r'C:\Multimodal Network Data\MultimodalScratchData.gdb\utransWhereClause' + source + '_' + strDate)
         #print('{0} cities that matched criteria written to {0}'.format(matchcount, utrans_IntersectedRoads))
 
     return 'utransQueried_lyr'
@@ -367,19 +368,19 @@ def get_SourceDataUsingDefQuery(where_clause, utransFeatureClass, source):
 
 def importTransitData():
     # import transit stops
-    transit_stops_multipoint = r'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MM_TransitData_02152019.gdb\\TransitStops' #### Note ####: change dates (if it's been updated) for fgdb to current dataset  
+    transit_stops_multipoint = r'C:\Multimodal Network Data\MM_TransitData_02152019.gdb\TransitStops' #### Note ####: change dates (if it's been updated) for fgdb to current dataset  
     # explode transit stops to single points (currently they are mulitpoints)
     print("explode multipoint stops to single points")
-    transit_stops_singlepoints = "C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\TranStops_" + strDate
+    transit_stops_singlepoints = r"C:\Multimodal Network Data\MultimodalScratchData.gdb\TranStops_" + strDate
     arcpy.FeatureVerticesToPoints_management(transit_stops_multipoint, transit_stops_singlepoints, "ALL")       
     print("import transit stops")
-    arcpy.FeatureClassToFeatureClass_conversion(transit_stops_singlepoints, r'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MM_NetworkDataset_' + strDate +  '.gdb\\NetworkDataset', 'TransitStops') #### Note ####: change dates (if it's been updated) for fgdb to current dataset 
+    arcpy.FeatureClassToFeatureClass_conversion(transit_stops_singlepoints, r'C:\Multimodal Network Data\MM_NetworkDataset_' + strDate +  r'.gdb\NetworkDataset', 'TransitStops') #### Note ####: change dates (if it's been updated) for fgdb to current dataset 
 
 
     # import the transit routes feature class
     # transit_route_source = r'C:\Users\gbunce\Documents\projects\MultimodalNetwork\MM_TransitData_02152019.gdb\TransitRoutes' #### Note ####: change transit data date (if it's been updated)
-    arcpy.FeatureClassToFeatureClass_conversion(transit_route_source, r'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MM_NetworkDataset_' + strDate +  '.gdb' + '\\NetworkDataset', 'TransitRoutes')
-    transit_routes_network_dataset =  r'C:\\Users\\gbunce\\Documents\\projects\\MultimodalNetwork\\MM_NetworkDataset_' + strDate +  '.gdb' + '\\NetworkDataset\\TransitRoutes'   
+    arcpy.FeatureClassToFeatureClass_conversion(transit_route_source, r'C:\Multimodal Network Data\MM_NetworkDataset_' + strDate +  '.gdb' + r'\NetworkDataset', 'TransitRoutes')
+    transit_routes_network_dataset =  r'C:\Multimodal Network Data\MM_NetworkDataset_' + strDate +  '.gdb' + r'\NetworkDataset\TransitRoutes'   
 
     # add miles field
     arcpy.AddField_management(transit_routes_network_dataset, "Length_Miles", "DOUBLE", "", "", "", "", "NULLABLE")
@@ -397,7 +398,7 @@ def importTransitData():
     #sgid_commuter_rail = r'C:\\Users\\gbunce\AppData\\Roaming\\ESRI\ArcGISPro\\Favorites\\internal@SGID@internal.agrc.utah.gov.sde\\SGID.TRANSPORTATION.CommuterRailRoutes_UTA'
     sgid_commuter_rail = 'https://maps.rideuta.com/server/rest/services/Hosted/UTA_FrontRunner_Commuter_Rail_Centerline/FeatureServer/0'
     # buffer the comm rail
-    sgid_commuter_rail_buff = r"C:\\Users\\gbunce\Documents\\projects\\MultimodalNetwork\\MultimodalScratchData.gdb\\SGID_CommRailBuff_" + strDate
+    sgid_commuter_rail_buff = r"C:\Multimodal Network Data\MultimodalScratchData.gdb\SGID_CommRailBuff_" + strDate
     arcpy.Buffer_analysis(sgid_commuter_rail, sgid_commuter_rail_buff, 30)
     # make feature layer of transit (required input for selection by location)
     arcpy.MakeFeatureLayer_management(transit_routes_network_dataset,'lyr_transit_fgdb')

--- a/create_network_data.py
+++ b/create_network_data.py
@@ -120,7 +120,7 @@ def main():
 def import_RoadsIntoNetworkDataset(utrans_roads_to_import):
     # get # Get the dictionary of codes and descriptions for cartocode field, for transfering descriptions to RoadClass network field
     # gdb = 'C:\\Users\\gbunce\AppData\\Roaming\\ESRI\ArcGISPro\\Favorites\\internal@SGID@internal.agrc.utah.gov.sde'
-    gdb = r'C:\Users\emneemann\AppData\Roaming\Esri\ArcGISPro\Favorites\internal.agrc.utah.gov (2).sde'
+    gdb = r"C:\Multimodal Network Data\internal.agrc.utah.gov.sde"
     desc_lu = [d.codedValues for d in arcpy.da.ListDomains(gdb) if d.name == 'CVDomain_CartoCode'][0]
     
     # create list of field names

--- a/create_network_data.py
+++ b/create_network_data.py
@@ -10,6 +10,10 @@ from commands.check_if_field_has_value import HasFieldValue
 from commands.calc_miles_and_time import calc_miles_time
 from commands.truncate_and_load import replace_bikepedauto_with_merged_and_split_data
 
+start_time = time.time()
+readable_start = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+print("The script start time is {}".format(readable_start))
+
 #arcpy.env.workspace = 'C:\Users\gbunce\Documents\projects\MultimodalNetwork'
 
 #: Notes before running: verify data sources (local SGID data vs SGID data -- home vpn vs at work). Variables to check:
@@ -442,3 +446,9 @@ def importTransitData():
 if __name__ == "__main__":
     # execute only if run as a script
     main()
+
+    print("Script shutting down ...")
+    # Stop timer and print end time in local time
+    readable_end = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+    print("The script end time is {}".format(readable_end))
+    print("Time elapsed: {:.2f}s".format(time.time() - start_time))

--- a/data/NDTemplate_update_20250702.xml
+++ b/data/NDTemplate_update_20250702.xml
@@ -1,0 +1,2728 @@
+<DENetworkDataset xsi:type='typens:DENetworkDataset'
+    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:typens='http://www.esri.com/schemas/ArcGIS/3.5.0'>
+    <CatalogPath>/FD=NetworkDataset/ND=NetworkDataset_ND</CatalogPath>
+    <Name>NetworkDataset_ND</Name>
+    <ChildrenExpanded>false</ChildrenExpanded>
+    <DatasetType>esriDTNetworkDataset</DatasetType>
+    <DSID>9</DSID>
+    <Versioned>false</Versioned>
+    <CanVersion>false</CanVersion>
+    <ConfigurationKeyword></ConfigurationKeyword>
+    <Extent xsi:type='typens:EnvelopeN'>
+        <XMin>244235.95999999996</XMin>
+        <YMin>4403204</YMin>
+        <XMax>512966.79999999981</XMax>
+        <YMax>4653336.6899999995</YMax>
+        <SpatialReference xsi:type='typens:ProjectedCoordinateSystem'>
+            <WKT>PROJCS[&quot;NAD_1983_UTM_Zone_12N&quot;,GEOGCS[&quot;GCS_North_American_1983&quot;,DATUM[&quot;D_North_American_1983&quot;,SPHEROID[&quot;GRS_1980&quot;,6378137.0,298.257222101]],PRIMEM[&quot;Greenwich&quot;,0.0],UNIT[&quot;Degree&quot;,0.0174532925199433]],PROJECTION[&quot;Transverse_Mercator&quot;],PARAMETER[&quot;False_Easting&quot;,500000.0],PARAMETER[&quot;False_Northing&quot;,0.0],PARAMETER[&quot;Central_Meridian&quot;,-111.0],PARAMETER[&quot;Scale_Factor&quot;,0.9996],PARAMETER[&quot;Latitude_Of_Origin&quot;,0.0],UNIT[&quot;Meter&quot;,1.0],AUTHORITY[&quot;EPSG&quot;,26912]]</WKT>
+            <XOrigin>-5120900</XOrigin>
+            <YOrigin>-9998100</YOrigin>
+            <XYScale>100</XYScale>
+            <ZOrigin>-100000</ZOrigin>
+            <ZScale>10000</ZScale>
+            <MOrigin>-100000</MOrigin>
+            <MScale>10000</MScale>
+            <XYTolerance>0.10000000000000001</XYTolerance>
+            <ZTolerance>0.001</ZTolerance>
+            <MTolerance>0.001</MTolerance>
+            <HighPrecision>true</HighPrecision>
+            <WKID>26912</WKID>
+            <LatestWKID>26912</LatestWKID>
+        </SpatialReference>
+    </Extent>
+    <SpatialReference xsi:type='typens:ProjectedCoordinateSystem'>
+        <WKT>PROJCS[&quot;NAD_1983_UTM_Zone_12N&quot;,GEOGCS[&quot;GCS_North_American_1983&quot;,DATUM[&quot;D_North_American_1983&quot;,SPHEROID[&quot;GRS_1980&quot;,6378137.0,298.257222101]],PRIMEM[&quot;Greenwich&quot;,0.0],UNIT[&quot;Degree&quot;,0.0174532925199433]],PROJECTION[&quot;Transverse_Mercator&quot;],PARAMETER[&quot;False_Easting&quot;,500000.0],PARAMETER[&quot;False_Northing&quot;,0.0],PARAMETER[&quot;Central_Meridian&quot;,-111.0],PARAMETER[&quot;Scale_Factor&quot;,0.9996],PARAMETER[&quot;Latitude_Of_Origin&quot;,0.0],UNIT[&quot;Meter&quot;,1.0],AUTHORITY[&quot;EPSG&quot;,26912]]</WKT>
+        <XOrigin>-5120900</XOrigin>
+        <YOrigin>-9998100</YOrigin>
+        <XYScale>100</XYScale>
+        <ZOrigin>-100000</ZOrigin>
+        <ZScale>10000</ZScale>
+        <MOrigin>-100000</MOrigin>
+        <MScale>10000</MScale>
+        <XYTolerance>0.10000000000000001</XYTolerance>
+        <ZTolerance>0.001</ZTolerance>
+        <MTolerance>0.001</MTolerance>
+        <HighPrecision>true</HighPrecision>
+        <WKID>26912</WKID>
+        <LatestWKID>26912</LatestWKID>
+    </SpatialReference>
+    <LogicalNetworkName>NetworkDataset_ND</LogicalNetworkName>
+    <NetworkType>1</NetworkType>
+    <Buildable>true</Buildable>
+    <SupportsTurns>true</SupportsTurns>
+    <Properties xsi:type='typens:PropertySet'>
+        <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+            <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                <Key>ServiceAreaSolverIndex</Key>
+                <Value xsi:type='typens:PropertySet'>
+                    <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                        <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                            <Key>TS1 meters</Key>
+                            <Value xsi:type='xs:double'>25</Value>
+                        </PropertySetProperty>
+                        <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                            <Key>TS1 native</Key>
+                            <Value xsi:type='xs:double'>25</Value>
+                        </PropertySetProperty>
+                        <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                            <Key>TS2 meters</Key>
+                            <Value xsi:type='xs:double'>5</Value>
+                        </PropertySetProperty>
+                        <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                            <Key>TS2 native</Key>
+                            <Value xsi:type='xs:double'>5</Value>
+                        </PropertySetProperty>
+                        <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                            <Key>IndexedAreaXMin</Key>
+                            <Value xsi:type='xs:double'>-5368397688.04</Value>
+                        </PropertySetProperty>
+                        <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                            <Key>IndexedAreaYMin</Key>
+                            <Value xsi:type='xs:double'>-5364243370</Value>
+                        </PropertySetProperty>
+                        <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                            <Key>IndexedAreaXMax</Key>
+                            <Value xsi:type='xs:double'>5369154890.8000002</Value>
+                        </PropertySetProperty>
+                        <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                            <Key>IndexedAreaYMax</Key>
+                            <Value xsi:type='xs:double'>5373299910.6899996</Value>
+                        </PropertySetProperty>
+                        <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                            <Key>BLOBFields</Key>
+                            <Value xsi:type='xs:string'>TS1,TS2</Value>
+                        </PropertySetProperty>
+                    </PropertyArray>
+                </Value>
+            </PropertySetProperty>
+        </PropertyArray>
+    </Properties>
+    <UserData xsi:nil='true'/>
+    <EdgeFeatureSources xsi:type='typens:ArrayOfEdgeFeatureSource'>
+        <EdgeFeatureSource xsi:type='typens:EdgeFeatureSource'>
+            <ID>1</ID>
+            <ClassID>4</ClassID>
+            <Name>BikePedAuto</Name>
+            <ElementType>esriNETEdge</ElementType>
+            <Properties xsi:nil='true'/>
+            <FromElevationFieldName></FromElevationFieldName>
+            <ToElevationFieldName></ToElevationFieldName>
+            <Connectivity xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>UsesSubtypes</Key>
+                        <Value xsi:type='xs:short'>0</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ClassConnectivity</Key>
+                        <Value xsi:type='xs:short'>0</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>SubtypeConnCount</Key>
+                        <Value xsi:type='xs:int'>0</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>DefaultGroup</Key>
+                        <Value xsi:type='xs:int'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>GroupCount</Key>
+                        <Value xsi:type='xs:int'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </Connectivity>
+        </EdgeFeatureSource>
+        <EdgeFeatureSource xsi:type='typens:EdgeFeatureSource'>
+            <ID>2</ID>
+            <ClassID>7</ClassID>
+            <Name>ConnectorNetwork</Name>
+            <ElementType>esriNETEdge</ElementType>
+            <Properties xsi:nil='true'/>
+            <FromElevationFieldName></FromElevationFieldName>
+            <ToElevationFieldName></ToElevationFieldName>
+            <Connectivity xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>UsesSubtypes</Key>
+                        <Value xsi:type='xs:short'>0</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ClassConnectivity</Key>
+                        <Value xsi:type='xs:short'>0</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>SubtypeConnCount</Key>
+                        <Value xsi:type='xs:int'>0</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>DefaultGroup</Key>
+                        <Value xsi:type='xs:int'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>GroupCount</Key>
+                        <Value xsi:type='xs:int'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </Connectivity>
+        </EdgeFeatureSource>
+        <EdgeFeatureSource xsi:type='typens:EdgeFeatureSource'>
+            <ID>3</ID>
+            <ClassID>6</ClassID>
+            <Name>TransitRoutes</Name>
+            <ElementType>esriNETEdge</ElementType>
+            <Properties xsi:nil='true'/>
+            <FromElevationFieldName></FromElevationFieldName>
+            <ToElevationFieldName></ToElevationFieldName>
+            <Connectivity xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>UsesSubtypes</Key>
+                        <Value xsi:type='xs:short'>0</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ClassConnectivity</Key>
+                        <Value xsi:type='xs:short'>0</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>SubtypeConnCount</Key>
+                        <Value xsi:type='xs:int'>0</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>DefaultGroup</Key>
+                        <Value xsi:type='xs:int'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>GroupCount</Key>
+                        <Value xsi:type='xs:int'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </Connectivity>
+        </EdgeFeatureSource>
+    </EdgeFeatureSources>
+    <JunctionFeatureSources xsi:type='typens:ArrayOfJunctionFeatureSource'>
+        <JunctionFeatureSource xsi:type='typens:JunctionFeatureSource'>
+            <ID>4</ID>
+            <ClassID>5</ClassID>
+            <Name>TransitStops</Name>
+            <ElementType>esriNETJunction</ElementType>
+            <Properties xsi:nil='true'/>
+            <ElevationFieldName></ElevationFieldName>
+            <Connectivity xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>UsesSubtypes</Key>
+                        <Value xsi:type='xs:short'>0</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ClassConnectivity</Key>
+                        <Value xsi:type='xs:short'>0</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>SubtypeConnCount</Key>
+                        <Value xsi:type='xs:int'>0</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ClassGroupsCount</Key>
+                        <Value xsi:type='xs:int'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ClassGroupName0</Key>
+                        <Value xsi:type='xs:int'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ClassGroupName1</Key>
+                        <Value xsi:type='xs:int'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>SubtypeGroupCount</Key>
+                        <Value xsi:type='xs:int'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </Connectivity>
+        </JunctionFeatureSource>
+    </JunctionFeatureSources>
+    <SystemJunctionSources xsi:type='typens:ArrayOfSystemJunctionSource'>
+        <SystemJunctionSource xsi:type='typens:SystemJunctionSource'>
+            <ID>5</ID>
+            <ClassID>8</ClassID>
+            <Name>NetworkDataset_ND_Junctions</Name>
+            <ElementType>esriNETJunction</ElementType>
+            <Properties xsi:nil='true'/>
+            <ElevationFieldName></ElevationFieldName>
+        </SystemJunctionSource>
+    </SystemJunctionSources>
+    <TurnFeatureSources xsi:type='typens:ArrayOfTurnFeatureSource'></TurnFeatureSources>
+    <EvaluatedNetworkAttributes xsi:type='typens:ArrayOfEvaluatedNetworkAttribute'>
+        <EvaluatedNetworkAttribute xsi:type='typens:EvaluatedNetworkAttribute'>
+            <ID>7</ID>
+            <Name>Mins_BikeOnly</Name>
+            <Units>Minutes</Units>
+            <DataType>esriNADTDouble</DataType>
+            <UsageType>esriNAUTCost</UsageType>
+            <UserData xsi:nil='true'/>
+            <UseByDefault>false</UseByDefault>
+            <AttributeParameters xsi:type='typens:ArrayOfNetworkAttributeParameter'></AttributeParameters>
+            <TimeAware>false</TimeAware>
+        </EvaluatedNetworkAttribute>
+        <EvaluatedNetworkAttribute xsi:type='typens:EvaluatedNetworkAttribute'>
+            <ID>11</ID>
+            <Name>Mins_BikeTransitOnly</Name>
+            <Units>Minutes</Units>
+            <DataType>esriNADTDouble</DataType>
+            <UsageType>esriNAUTCost</UsageType>
+            <UserData xsi:nil='true'/>
+            <UseByDefault>false</UseByDefault>
+            <AttributeParameters xsi:type='typens:ArrayOfNetworkAttributeParameter'></AttributeParameters>
+            <TimeAware>false</TimeAware>
+        </EvaluatedNetworkAttribute>
+        <EvaluatedNetworkAttribute xsi:type='typens:EvaluatedNetworkAttribute'>
+            <ID>15</ID>
+            <Name>Mins_DriveOnly</Name>
+            <Units>Minutes</Units>
+            <DataType>esriNADTDouble</DataType>
+            <UsageType>esriNAUTCost</UsageType>
+            <UserData xsi:nil='true'/>
+            <UseByDefault>false</UseByDefault>
+            <AttributeParameters xsi:type='typens:ArrayOfNetworkAttributeParameter'></AttributeParameters>
+            <TimeAware>false</TimeAware>
+        </EvaluatedNetworkAttribute>
+        <EvaluatedNetworkAttribute xsi:type='typens:EvaluatedNetworkAttribute'>
+            <ID>2</ID>
+            <Name>Mins_PedOnly</Name>
+            <Units>Minutes</Units>
+            <DataType>esriNADTDouble</DataType>
+            <UsageType>esriNAUTCost</UsageType>
+            <UserData xsi:nil='true'/>
+            <UseByDefault>false</UseByDefault>
+            <AttributeParameters xsi:type='typens:ArrayOfNetworkAttributeParameter'></AttributeParameters>
+            <TimeAware>false</TimeAware>
+        </EvaluatedNetworkAttribute>
+        <EvaluatedNetworkAttribute xsi:type='typens:EvaluatedNetworkAttribute'>
+            <ID>13</ID>
+            <Name>Mins_PedTransitOnly</Name>
+            <Units>Minutes</Units>
+            <DataType>esriNADTDouble</DataType>
+            <UsageType>esriNAUTCost</UsageType>
+            <UserData xsi:nil='true'/>
+            <UseByDefault>true</UseByDefault>
+            <AttributeParameters xsi:type='typens:ArrayOfNetworkAttributeParameter'></AttributeParameters>
+            <TimeAware>false</TimeAware>
+        </EvaluatedNetworkAttribute>
+        <EvaluatedNetworkAttribute xsi:type='typens:EvaluatedNetworkAttribute'>
+            <ID>17</ID>
+            <Name>Mins_TransitOnly</Name>
+            <Units>Minutes</Units>
+            <DataType>esriNADTDouble</DataType>
+            <UsageType>esriNAUTCost</UsageType>
+            <UserData xsi:nil='true'/>
+            <UseByDefault>false</UseByDefault>
+            <AttributeParameters xsi:type='typens:ArrayOfNetworkAttributeParameter'></AttributeParameters>
+            <TimeAware>false</TimeAware>
+        </EvaluatedNetworkAttribute>
+        <EvaluatedNetworkAttribute xsi:type='typens:EvaluatedNetworkAttribute'>
+            <ID>3</ID>
+            <Name>Miles</Name>
+            <Units>Miles</Units>
+            <DataType>esriNADTDouble</DataType>
+            <UsageType>esriNAUTCost</UsageType>
+            <UserData xsi:nil='true'/>
+            <UseByDefault>false</UseByDefault>
+            <AttributeParameters xsi:type='typens:ArrayOfNetworkAttributeParameter'></AttributeParameters>
+            <TimeAware>false</TimeAware>
+        </EvaluatedNetworkAttribute>
+        <EvaluatedNetworkAttribute xsi:type='typens:EvaluatedNetworkAttribute'>
+            <ID>10</ID>
+            <Name>Network_BikeOnly</Name>
+            <Units>Unknown</Units>
+            <DataType>esriNADTBoolean</DataType>
+            <UsageType>esriNAUTRestriction</UsageType>
+            <UserData xsi:nil='true'/>
+            <UseByDefault>false</UseByDefault>
+            <AttributeParameters xsi:type='typens:ArrayOfNetworkAttributeParameter'>
+                <NetworkAttributeParameter xsi:type='typens:NetworkAttributeParameter'>
+                    <Name>Restriction Usage</Name>
+                    <VarType>5</VarType>
+                    <Value xsi:type='xs:double'>-1</Value>
+                    <DefaultValue xsi:type='xs:double'>-1</DefaultValue>
+                    <ParameterUsageType>esriNAPUTRestriction</ParameterUsageType>
+                </NetworkAttributeParameter>
+            </AttributeParameters>
+            <TimeAware>false</TimeAware>
+        </EvaluatedNetworkAttribute>
+        <EvaluatedNetworkAttribute xsi:type='typens:EvaluatedNetworkAttribute'>
+            <ID>12</ID>
+            <Name>Network_BikeTransitOnly</Name>
+            <Units>Unknown</Units>
+            <DataType>esriNADTBoolean</DataType>
+            <UsageType>esriNAUTRestriction</UsageType>
+            <UserData xsi:nil='true'/>
+            <UseByDefault>false</UseByDefault>
+            <AttributeParameters xsi:type='typens:ArrayOfNetworkAttributeParameter'>
+                <NetworkAttributeParameter xsi:type='typens:NetworkAttributeParameter'>
+                    <Name>Restriction Usage</Name>
+                    <VarType>5</VarType>
+                    <Value xsi:type='xs:double'>-1</Value>
+                    <DefaultValue xsi:type='xs:double'>-1</DefaultValue>
+                    <ParameterUsageType>esriNAPUTRestriction</ParameterUsageType>
+                </NetworkAttributeParameter>
+            </AttributeParameters>
+            <TimeAware>false</TimeAware>
+        </EvaluatedNetworkAttribute>
+        <EvaluatedNetworkAttribute xsi:type='typens:EvaluatedNetworkAttribute'>
+            <ID>16</ID>
+            <Name>Network_DriveOnly</Name>
+            <Units>Unknown</Units>
+            <DataType>esriNADTBoolean</DataType>
+            <UsageType>esriNAUTRestriction</UsageType>
+            <UserData xsi:nil='true'/>
+            <UseByDefault>false</UseByDefault>
+            <AttributeParameters xsi:type='typens:ArrayOfNetworkAttributeParameter'>
+                <NetworkAttributeParameter xsi:type='typens:NetworkAttributeParameter'>
+                    <Name>Restriction Usage</Name>
+                    <VarType>5</VarType>
+                    <Value xsi:type='xs:double'>-1</Value>
+                    <DefaultValue xsi:type='xs:double'>-1</DefaultValue>
+                    <ParameterUsageType>esriNAPUTRestriction</ParameterUsageType>
+                </NetworkAttributeParameter>
+            </AttributeParameters>
+            <TimeAware>false</TimeAware>
+        </EvaluatedNetworkAttribute>
+        <EvaluatedNetworkAttribute xsi:type='typens:EvaluatedNetworkAttribute'>
+            <ID>9</ID>
+            <Name>Network_PedOnly</Name>
+            <Units>Unknown</Units>
+            <DataType>esriNADTBoolean</DataType>
+            <UsageType>esriNAUTRestriction</UsageType>
+            <UserData xsi:nil='true'/>
+            <UseByDefault>false</UseByDefault>
+            <AttributeParameters xsi:type='typens:ArrayOfNetworkAttributeParameter'>
+                <NetworkAttributeParameter xsi:type='typens:NetworkAttributeParameter'>
+                    <Name>Restriction Usage</Name>
+                    <VarType>5</VarType>
+                    <Value xsi:type='xs:double'>-1</Value>
+                    <DefaultValue xsi:type='xs:double'>-1</DefaultValue>
+                    <ParameterUsageType>esriNAPUTRestriction</ParameterUsageType>
+                </NetworkAttributeParameter>
+            </AttributeParameters>
+            <TimeAware>false</TimeAware>
+        </EvaluatedNetworkAttribute>
+        <EvaluatedNetworkAttribute xsi:type='typens:EvaluatedNetworkAttribute'>
+            <ID>14</ID>
+            <Name>Network_PedTransitOnly</Name>
+            <Units>Unknown</Units>
+            <DataType>esriNADTBoolean</DataType>
+            <UsageType>esriNAUTRestriction</UsageType>
+            <UserData xsi:nil='true'/>
+            <UseByDefault>true</UseByDefault>
+            <AttributeParameters xsi:type='typens:ArrayOfNetworkAttributeParameter'>
+                <NetworkAttributeParameter xsi:type='typens:NetworkAttributeParameter'>
+                    <Name>Restriction Usage</Name>
+                    <VarType>5</VarType>
+                    <Value xsi:type='xs:double'>-1</Value>
+                    <DefaultValue xsi:type='xs:double'>-1</DefaultValue>
+                    <ParameterUsageType>esriNAPUTRestriction</ParameterUsageType>
+                </NetworkAttributeParameter>
+            </AttributeParameters>
+            <TimeAware>false</TimeAware>
+        </EvaluatedNetworkAttribute>
+        <EvaluatedNetworkAttribute xsi:type='typens:EvaluatedNetworkAttribute'>
+            <ID>18</ID>
+            <Name>Network_TransitOnly</Name>
+            <Units>Unknown</Units>
+            <DataType>esriNADTBoolean</DataType>
+            <UsageType>esriNAUTRestriction</UsageType>
+            <UserData xsi:nil='true'/>
+            <UseByDefault>false</UseByDefault>
+            <AttributeParameters xsi:type='typens:ArrayOfNetworkAttributeParameter'>
+                <NetworkAttributeParameter xsi:type='typens:NetworkAttributeParameter'>
+                    <Name>Restriction Usage</Name>
+                    <VarType>5</VarType>
+                    <Value xsi:type='xs:double'>-1</Value>
+                    <DefaultValue xsi:type='xs:double'>-1</DefaultValue>
+                    <ParameterUsageType>esriNAPUTRestriction</ParameterUsageType>
+                </NetworkAttributeParameter>
+            </AttributeParameters>
+            <TimeAware>false</TimeAware>
+        </EvaluatedNetworkAttribute>
+        <EvaluatedNetworkAttribute xsi:type='typens:EvaluatedNetworkAttribute'>
+            <ID>1</ID>
+            <Name>Oneway</Name>
+            <Units>Unknown</Units>
+            <DataType>esriNADTBoolean</DataType>
+            <UsageType>esriNAUTRestriction</UsageType>
+            <UserData xsi:nil='true'/>
+            <UseByDefault>false</UseByDefault>
+            <AttributeParameters xsi:type='typens:ArrayOfNetworkAttributeParameter'>
+                <NetworkAttributeParameter xsi:type='typens:NetworkAttributeParameter'>
+                    <Name>Restriction Usage</Name>
+                    <VarType>5</VarType>
+                    <Value xsi:type='xs:double'>-1</Value>
+                    <DefaultValue xsi:type='xs:double'>-1</DefaultValue>
+                    <ParameterUsageType>esriNAPUTRestriction</ParameterUsageType>
+                </NetworkAttributeParameter>
+            </AttributeParameters>
+            <TimeAware>false</TimeAware>
+        </EvaluatedNetworkAttribute>
+    </EvaluatedNetworkAttributes>
+    <NetworkAssignments xsi:type='typens:ArrayOfNetworkAssignment'>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_BikeOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETJunction</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_BikeOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETEdge</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_BikeOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETTurn</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_BikeOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!BikeTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_BikeOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!BikeTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_BikeTransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETJunction</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_BikeTransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETEdge</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_BikeTransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETTurn</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_BikeTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!BikeTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_BikeTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!BikeTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_BikeTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>ConnectorNetwork</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!PedestrianTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_BikeTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>ConnectorNetwork</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!PedestrianTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_BikeTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>TransitRoutes</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!TransitTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_BikeTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>TransitRoutes</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!TransitTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_DriveOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETJunction</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_DriveOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETEdge</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_DriveOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETTurn</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_DriveOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!DriveTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_DriveOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!DriveTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_PedOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETJunction</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_PedOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETEdge</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_PedOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETTurn</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_PedOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!PedestrianTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_PedOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!PedestrianTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_PedTransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETJunction</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_PedTransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETEdge</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_PedTransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETTurn</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_PedTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!PedestrianTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_PedTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!PedestrianTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_PedTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>ConnectorNetwork</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!PedestrianTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_PedTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>ConnectorNetwork</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!PedestrianTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_PedTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>TransitRoutes</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!TransitTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_PedTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>TransitRoutes</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!TransitTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_TransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETJunction</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_TransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETEdge</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_TransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETTurn</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_TransitOnly</NetworkAttributeName>
+            <NetworkSourceName>TransitRoutes</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!TransitTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Mins_TransitOnly</NetworkAttributeName>
+            <NetworkSourceName>TransitRoutes</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!TransitTime!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Miles</NetworkAttributeName>
+            <NetworkElementType>esriNETJunction</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Miles</NetworkAttributeName>
+            <NetworkElementType>esriNETEdge</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Miles</NetworkAttributeName>
+            <NetworkElementType>esriNETTurn</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:double'>0</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Miles</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!Length_Miles!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Miles</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!Length_Miles!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Miles</NetworkAttributeName>
+            <NetworkSourceName>ConnectorNetwork</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!Length_Miles!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Miles</NetworkAttributeName>
+            <NetworkSourceName>ConnectorNetwork</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!Length_Miles!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Miles</NetworkAttributeName>
+            <NetworkSourceName>TransitRoutes</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!Length_Miles!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Miles</NetworkAttributeName>
+            <NetworkSourceName>TransitRoutes</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>!Length_Miles!</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'></Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_BikeOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETJunction</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_BikeOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETEdge</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_BikeOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETTurn</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_BikeOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>set_restriction(!BikeNetwork!)</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'>def set_restriction(bike_network):
+    return bike_network.upper() == &quot;N&quot;</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_BikeOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>set_restriction(!BikeNetwork!)</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'>def set_restriction(bike_network):
+    return bike_network.upper() == &quot;N&quot;</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_BikeOnly</NetworkAttributeName>
+            <NetworkSourceName>ConnectorNetwork</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_BikeOnly</NetworkAttributeName>
+            <NetworkSourceName>ConnectorNetwork</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_BikeOnly</NetworkAttributeName>
+            <NetworkSourceName>TransitRoutes</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_BikeOnly</NetworkAttributeName>
+            <NetworkSourceName>TransitRoutes</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_BikeTransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETJunction</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_BikeTransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETEdge</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_BikeTransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETTurn</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_BikeTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>set_restriction(!BikeNetwork!)</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'>def set_restriction(bike_network):
+    return bike_network.upper() == &quot;N&quot;</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_BikeTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>set_restriction(!BikeNetwork!)</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'>def set_restriction(bike_network):
+    return bike_network.upper() == &quot;N&quot;</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_DriveOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETJunction</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_DriveOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETEdge</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_DriveOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETTurn</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_DriveOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>set_restriction(!AutoNetwork!)</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'>def set_restriction(auto_network):
+    return auto_network.upper() == &quot;N&quot;</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_DriveOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>set_restriction(!AutoNetwork!)</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'>def set_restriction(auto_network):
+    return auto_network.upper() == &quot;N&quot;</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_DriveOnly</NetworkAttributeName>
+            <NetworkSourceName>ConnectorNetwork</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_DriveOnly</NetworkAttributeName>
+            <NetworkSourceName>ConnectorNetwork</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_DriveOnly</NetworkAttributeName>
+            <NetworkSourceName>TransitRoutes</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_DriveOnly</NetworkAttributeName>
+            <NetworkSourceName>TransitRoutes</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_PedOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETJunction</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_PedOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETEdge</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_PedOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETTurn</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_PedOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>set_restriction(!PedNetwork!)</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'>def set_restriction(ped_network):
+    return ped_network.upper() == &quot;N&quot;</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_PedOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>set_restriction(!PedNetwork!)</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'>def set_restriction(ped_network):
+    return ped_network.upper() == &quot;N&quot;</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_PedOnly</NetworkAttributeName>
+            <NetworkSourceName>ConnectorNetwork</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_PedOnly</NetworkAttributeName>
+            <NetworkSourceName>ConnectorNetwork</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_PedOnly</NetworkAttributeName>
+            <NetworkSourceName>TransitRoutes</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_PedOnly</NetworkAttributeName>
+            <NetworkSourceName>TransitRoutes</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_PedTransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETJunction</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_PedTransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETEdge</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_PedTransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETTurn</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_PedTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>set_restriction(!PedNetwork!)</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'>def set_restriction(ped_network):
+    return ped_network.upper() == &quot;N&quot;</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_PedTransitOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>set_restriction(!PedNetwork!)</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'>def set_restriction(ped_network):
+    return ped_network.upper() == &quot;N&quot;</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_TransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETJunction</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_TransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETEdge</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_TransitOnly</NetworkAttributeName>
+            <NetworkElementType>esriNETTurn</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_TransitOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_TransitOnly</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_TransitOnly</NetworkAttributeName>
+            <NetworkSourceName>ConnectorNetwork</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Network_TransitOnly</NetworkAttributeName>
+            <NetworkSourceName>ConnectorNetwork</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>true</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Oneway</NetworkAttributeName>
+            <NetworkElementType>esriNETJunction</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Oneway</NetworkAttributeName>
+            <NetworkElementType>esriNETEdge</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>true</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Oneway</NetworkAttributeName>
+            <NetworkElementType>esriNETTurn</NetworkElementType>
+            <NetworkEvaluatorCLSID>{318C4B91-F5D2-467A-996C-0AB51B0D8FF2}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDNone</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>1</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>ConstantValue</Key>
+                        <Value xsi:type='xs:boolean'>false</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Oneway</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAlongDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>set_restriction(!Oneway!)</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'>def set_restriction(oneway):
+    return oneway.upper() in [&apos;N&apos;, &apos;TF&apos;, &apos;T&apos;]</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+        <NetworkAssignment xsi:type='typens:NetworkAssignment'>
+            <IsDefault>false</IsDefault>
+            <ID>-1</ID>
+            <NetworkAttributeName>Oneway</NetworkAttributeName>
+            <NetworkSourceName>BikePedAuto</NetworkSourceName>
+            <NetworkEvaluatorCLSID>{68055FC4-37D5-4BD0-81A5-CD177A29759C}</NetworkEvaluatorCLSID>
+            <NetworkEdgeDirection>esriNEDAgainstDigitized</NetworkEdgeDirection>
+            <NetworkEvaluatorData xsi:type='typens:PropertySet'>
+                <PropertyArray xsi:type='typens:ArrayOfPropertySetProperty'>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Version</Key>
+                        <Value xsi:type='xs:short'>2</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Expression</Key>
+                        <Value xsi:type='xs:string'>set_restriction(!Oneway!)</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>PreLogic</Key>
+                        <Value xsi:type='xs:string'>def set_restriction(oneway):
+    return oneway.upper() in [&apos;N&apos;, &apos;TF&apos;, &apos;T&apos;]</Value>
+                    </PropertySetProperty>
+                    <PropertySetProperty xsi:type='typens:PropertySetProperty'>
+                        <Key>Language</Key>
+                        <Value xsi:type='xs:string'>Python</Value>
+                    </PropertySetProperty>
+                </PropertyArray>
+            </NetworkEvaluatorData>
+        </NetworkAssignment>
+    </NetworkAssignments>
+    <HierarchyMaxValues xsi:type='typens:ArrayOfInt'></HierarchyMaxValues>
+    <NetworkElevationModel>0</NetworkElevationModel>
+    <LogicalNetworkID>1</LogicalNetworkID>
+    <SchemaGeneration>4</SchemaGeneration>
+    <BuildTime>1749680540</BuildTime>
+</DENetworkDataset>


### PR DESCRIPTION
I buried the lead, these edits will repoint to a new network dataset template that uses Python calculations instead of deprecated VBScript.  The XML template has also been added to the data folder and needs to be placed in the location noted in the "create_network.py" script.  These changes allow the network dataset to be build with ArcGIS Pro 3.5+ and will close #2.

These scripts also have a bunch of references to Greg's user folder, so I simplified them to point to the C Drive on our VM.  A couple other very minor code changes.